### PR TITLE
Add code block to install doc to fix formatting

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -159,11 +159,11 @@ If you follow the below steps on greed field, configured, Red Hat CloudForms app
 
 
 *   Clone miq-RedHat-Satellite6 repository
-    *   git clone https://github.com/RedHatOfficial/miq-RedHat-Satellite6.git
+    *   `git clone https://github.com/RedHatOfficial/miq-RedHat-Satellite6.git`
 *   Import Service Dialog
-    *   miqimport service_dialogs miq-RedHat-Satellite6/Dialogs/<version>
+    *   `miqimport service_dialogs miq-RedHat-Satellite6/Dialogs/<version>`
 *   Import Catalog
-    *   miqimport service_catalogs miq-RedHat-Satellite6/Catalogs/<version>
+    *   `miqimport service_catalogs miq-RedHat-Satellite6/Catalogs/<version>`
 
 
 # Tagging:


### PR DESCRIPTION
This fixes the issue where the version tag was not displayed at the end of the miqimport commands.

Before:

![image](https://user-images.githubusercontent.com/4661604/59518876-a5d4c700-8e94-11e9-8a47-14a4f6a9fa13.png)

After:

![image](https://user-images.githubusercontent.com/4661604/59518905-b5541000-8e94-11e9-8b89-12fe9cac91b1.png)

Addresses #93 