### PR TITLE
Add field to all api search calls

### DIFF
--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/register_satellite.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/register_satellite.rb
@@ -307,7 +307,7 @@ begin
   satellite_config      = $evm.instantiate(SATELLITE_CONFIG_URI)
   satellite_owner_group = satellite_config['satellite_owner_group']
   if !satellite_owner_group.nil?
-    satellite_usergroups_result = satellite_api.resource(:usergroups).call(:index, {:search => "#{satellite_owner_group}"})
+    satellite_usergroups_result = satellite_api.resource(:usergroups).call(:index, {:search => "name=#{satellite_owner_group}"})
     satellite_usergroup         = satellite_usergroups_result['results'].first
   end
   

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/set_user_data.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/set_user_data.rb
@@ -178,7 +178,7 @@ end
 # @return Hash Satellite host record for the given host name returned from Satellite API
 def get_satellite_host_record(satellite_api, name)
   begin
-    satellite_index_result = satellite_api.resource(:hosts).call(:index, {:search => "#{name}"})
+    satellite_index_result = satellite_api.resource(:hosts).call(:index, {:search => "name=#{name}"})
     if !satellite_index_result['results'].empty?
       satellite_host_record  = satellite_index_result['results'][0]
       

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/unregister_satellite.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/unregister_satellite.rb
@@ -55,7 +55,7 @@ end
 def get_satellite_host_record(satellite_api, name)
   satellite_host_record = nil
   begin
-    satellite_index_result = satellite_api.resource(:hosts).call(:index, {:search => "#{name}"})
+    satellite_index_result = satellite_api.resource(:hosts).call(:index, {:search => "name=#{name}"})
     if !satellite_index_result['results'].empty?
       satellite_host_record  = satellite_index_result['results'][0]
       

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/update_satellite.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/update_satellite.rb
@@ -173,7 +173,7 @@ end
 def get_satellite_host_record(satellite_api, name)
   satellite_host_record = nil
   begin
-    satellite_index_result = satellite_api.resource(:hosts).call(:index, {:search => "#{name}"})
+    satellite_index_result = satellite_api.resource(:hosts).call(:index, {:search => "name=#{name}"})
     if !satellite_index_result['results'].empty?
       satellite_host_record = satellite_index_result['results'].first
       

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/StdLib.class/__methods__/satellitecore.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/StdLib.class/__methods__/satellitecore.rb
@@ -49,7 +49,7 @@ module RedHatConsulting_Satellite6
       def get_satellite_host_record(satellite_api, name)
         satellite_host_record = nil
         begin
-          satellite_index_result = satellite_api.resource(:hosts).call(:index, {:search => "#{name}"})
+          satellite_index_result = satellite_api.resource(:hosts).call(:index, {:search => "name=#{name}"})
           if !satellite_index_result['results'].empty?
             satellite_host_record = satellite_index_result['results'].first
 


### PR DESCRIPTION
Due to apparent change of behavior in satellite 6.7 and later more results than expected may get returned with `?search=<name>` uri params.

For predictable results, a field must be included in your search, such as `?search=name=<name>`