### PR TITLE
Later version of Apipie requires ssl_verification to configured to of…

### DIFF
--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_domains_by_location.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_domains_by_location.rb
@@ -87,7 +87,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_hostgroups.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_hostgroups.rb
@@ -33,7 +33,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_lifecycle_environments.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_lifecycle_environments.rb
@@ -33,7 +33,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_lifecycle_environments_filtered_by_tags.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_lifecycle_environments_filtered_by_tags.rb
@@ -165,7 +165,7 @@ module RedHatConsulting_Satellite6
               error("Satellite User configuration not found")     if satellite_username.nil?
               error("Satellite Password configuration not found") if satellite_password.nil?
 
-              satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+              satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
               log(:info, "satellite_api = #{satellite_api}") if @DEBUG
               return satellite_api
             end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_locations.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_locations.rb
@@ -33,7 +33,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_locations_by_tag_path.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_locations_by_tag_path.rb
@@ -105,7 +105,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_locations_filtered_by_tags.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_locations_filtered_by_tags.rb
@@ -102,7 +102,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_organizations.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_organizations.rb
@@ -33,7 +33,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_templates_based_on_selected_os_and_location_and_environment.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/DynamicDialogs.class/__methods__/get_templates_based_on_selected_os_and_location_and_environment.rb
@@ -251,7 +251,7 @@ module RedHatConsulting_Satellite6
               error("Satellite User configuration not found")     if satellite_username.nil?
               error("Satellite Password configuration not found") if satellite_password.nil?
               
-              satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+              satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
               log(:info, "satellite_api = #{satellite_api}") if @DEBUG
               return satellite_api
             end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/check_satellite_build_completed.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/check_satellite_build_completed.rb
@@ -39,7 +39,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/register_satellite.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/register_satellite.rb
@@ -189,7 +189,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/set_user_data.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/set_user_data.rb
@@ -165,7 +165,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/unregister_satellite.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/unregister_satellite.rb
@@ -41,7 +41,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/update_satellite.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/update_satellite.rb
@@ -159,7 +159,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/StdLib.class/__methods__/satellitecore.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/StdLib.class/__methods__/satellitecore.rb
@@ -34,7 +34,7 @@ module RedHatConsulting_Satellite6
         error("Satellite User configuration not found")     if satellite_username.nil?
         error("Satellite Password configuration not found") if satellite_password.nil?
 
-        satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+        satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
         log(:info, "satellite_api = #{satellite_api}") if @DEBUG
         return satellite_api
 

--- a/Automate/RedHatConsulting_Satellite6/Service/Provisioning/StateMachines/Methods.class/__methods__/set_custom_provision_task_options.rb
+++ b/Automate/RedHatConsulting_Satellite6/Service/Provisioning/StateMachines/Methods.class/__methods__/set_custom_provision_task_options.rb
@@ -77,7 +77,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end

--- a/Automate/RedHatConsulting_Satellite6/Service/Provisioning/StateMachines/Methods.class/__methods__/set_satellite_options.rb
+++ b/Automate/RedHatConsulting_Satellite6/Service/Provisioning/StateMachines/Methods.class/__methods__/set_satellite_options.rb
@@ -46,7 +46,7 @@ def get_satellite_api()
   error("Satellite User configuration not found")     if satellite_username.nil?
   error("Satellite Password configuration not found") if satellite_password.nil?
   
-  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2})
+  satellite_api = ApipieBindings::API.new({:uri => satellite_server, :username => satellite_username, :password => satellite_password, :api_version => 2, :apidoc_cache_dir => "/tmp/foreman" }, {:verify_ssl => false})
   $evm.log(:info, "satellite_api = #{satellite_api}") if @DEBUG
   return satellite_api
 end


### PR DESCRIPTION
Later version of Apipie requires ssl_verification to configured to off to connect to Foreman/Satellite.

Because /home/manageiq does not exist even though the application now runs as the manageiq user, a temp directory need to be defined for Apipie to be able to create temporary files.

Fixes #103 